### PR TITLE
Modificaciones en el app.component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,11 @@
-<!--The whole content below can be removed with the new code.-->
+<!--
+Me costo encontrar el error,
+resulta que se te olvido cerrar la etiqueta del app-navbar
+lo tenías así
 <app-navbar><app-navbar>
+-->
+
+<app-navbar></app-navbar>
 <div class="container">
   <router-outlet></router-outlet>
 </div>


### PR DESCRIPTION
### Faltaba una simple "/"

Si te fijas, originalmente estaba así
<app-navbar><app-navbar>

y es así
<app-navbar></app-navbar>

Lo que hacía no se mostrara correctamente el otro componente.